### PR TITLE
Update deps with cargo upgrade and remove unused deps with cargo machete

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,18 +7,14 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-anyhow = "1.0.86"
-base64 = "0.22.1"
-chrono = "0.4.41"
+anyhow = "1.0.98"
 jwt-simple = "0.12.12"
-pem = "3.0.5"
 serde = "1.0"
 serde_json = "1.0"
 serde_urlencoded = "0.7.1"
-url = "2.5.4"
-wit-bindgen = "0.41.0"
+wit-bindgen = "0.43.0"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"
-uuid = { version = "1.10.0", features = ["v4"] }
+uuid = { version = "1.17.0", features = ["v4"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
```
$ cargo upgrade

Checking bigquery-component's dependencies
name   old req compatible latest new req
====   ======= ========== ====== =======
anyhow 1.0.86  1.0.98     1.0.98 1.0.98 
uuid   1.10.0  1.17.0     1.17.0 1.17.0 
```