### PR TITLE
Fix build command to handle hardlink issue on Linux

### DIFF
--- a/edgee-component.toml
+++ b/edgee-component.toml
@@ -18,7 +18,7 @@ language = "Rust"
 wit-version = "1.0.1"
 
 [component.build]
-command = "cargo build --target wasm32-wasip2 --release --target-dir ./target && mv ./target/wasm32-wasip2/release/bigquery_component.wasm ./bigquery.wasm"
+command = "cargo build --target wasm32-wasip2 --release --target-dir ./target && rm -f ./bigquery.wasm && mv ./target/wasm32-wasip2/release/bigquery_component.wasm ./bigquery.wasm"
 output_path = "bigquery.wasm"
 
 [component.settings.service_json]


### PR DESCRIPTION
## Summary
- Add `rm -f [output_file]` before `mv`/`cp` operations in build commands
- Prevents "cannot move file to itself" errors on Linux where output WASM file is already a hardlink